### PR TITLE
remove unnecessary json tag annotation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,57 +1,54 @@
 package client
 
 import (
-	"cloud.google.com/go/firestore"
 	"net/http"
 	"time"
+
+	"cloud.google.com/go/firestore"
 )
 
 const FuzzitEndpoint = "https://app.fuzzit.dev"
 const CacheFile = "/tmp/.fuzzit.cache"
-
 
 type Target struct {
 	Name string `firestore:"target_name"`
 }
 
 type Job struct {
-	TargetId string  	`firestore:"target_id"`
-	Args string  		`firestore:"args"`
-	Type string 		`firestore:"type"`
-	Host string 		`firestore:"host"`
-	Revision string		`firestore:"revision"`
-	Branch string		`firestore:"branch"`
-	Parallelism uint16  `firestore:"parallelism"`
-	AsanOptions string  `firestore:"asan_options"`
+	TargetId     string `firestore:"target_id"`
+	Args         string `firestore:"args"`
+	Type         string `firestore:"type"`
+	Host         string `firestore:"host"`
+	Revision     string `firestore:"revision"`
+	Branch       string `firestore:"branch"`
+	Parallelism  uint16 `firestore:"parallelism"`
+	AsanOptions  string `firestore:"asan_options"`
 	UbsanOptions string `firestore:"ubsan_options"`
 }
 
-
 // Internal struct
 type job struct {
-	Completed uint16 	`firestore:"completed"`
-	Status string 		`firestore:"status"`
-	Namespace string 	`firestore:"namespace"`
+	Completed uint16    `firestore:"completed"`
+	Status    string    `firestore:"status"`
+	Namespace string    `firestore:"namespace"`
 	StartedAt time.Time `firestore:"started_at,serverTimestamp"`
-	OrgId string 		`firestore:"org_id"`
+	OrgId     string    `firestore:"org_id"`
 	Job
 }
 
-
 type fuzzitClient struct {
-	Org string
-	Namespace string
-	ApiKey string
-	CustomToken string
-	Kind string `json:"kind"`
-	IdToken string `json:"idToken"`
-	RefreshToken string `json:"refreshToken"`
-	ExpiresIn string `json:"expiresIn"`
-	LastRefresh int64
-	firestoreClient *firestore.Client `json:"-"`
-	httpClient *http.Client `json:"-"`
+	Org             string
+	Namespace       string
+	ApiKey          string
+	CustomToken     string
+	Kind            string `json:"kind"`
+	IdToken         string `json:"idToken"`
+	RefreshToken    string `json:"refreshToken"`
+	ExpiresIn       string `json:"expiresIn"`
+	LastRefresh     int64
+	firestoreClient *firestore.Client
+	httpClient      *http.Client
 }
-
 
 func NewFuzzitClient(apiKey string) *fuzzitClient {
 	c := &fuzzitClient{}
@@ -71,4 +68,3 @@ func LoadFuzzitFromCache() (*fuzzitClient, error) {
 
 	return c, nil
 }
-


### PR DESCRIPTION
In Go private struct fields (whose name starts with lowercase) are not serialized by `json.Marshall` so no need to annotate them with `json:"-"` tag.
