### PR TITLE
make fileCopy more robust

### DIFF
--- a/client/utils.go
+++ b/client/utils.go
@@ -26,7 +26,14 @@ func copyFile(dst, src string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer destination.Close()
 	nBytes, err := io.Copy(destination, source)
-	return nBytes, err
+	errClose := destination.Close()
+	if err != nil {
+		return 0, err
+	}
+	if errClose != nil {
+		return 0, errClose
+	}
+
+	return nBytes, nil
 }


### PR DESCRIPTION
It's unlikely to happen, but `Close()` on a file being written to can fail due to unflushed os buffers. `Close` might fail even though `io.Copy` said it wrote all the data to the destination.

Does not apply to files being read from so no need to check error from `source.Close()`

