### PR TITLE
all: apply gofumpt

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,11 +1,12 @@
 package client
 
 import (
-	"cloud.google.com/go/firestore"
 	"encoding/json"
 	"net/http"
 	"os"
 	"time"
+
+	"cloud.google.com/go/firestore"
 )
 
 const FuzzitEndpoint = "https://app.fuzzit.dev"
@@ -88,7 +89,7 @@ func LoadFuzzitFromCache() (*FuzzitClient, error) {
 		return nil, err
 	}
 
-	//if c.ApiKey == "" {
+	// if c.ApiKey == "" {
 	//	return errors.New("API Key is not configured (will have access only to public repositories)")
 	//}
 

--- a/client/commands.go
+++ b/client/commands.go
@@ -2,16 +2,9 @@ package client
 
 import (
 	"archive/tar"
-	"cloud.google.com/go/firestore"
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/google/uuid"
-	"github.com/mholt/archiver"
-	"google.golang.org/api/iterator"
 	"io"
 	"io/ioutil"
 	"log"
@@ -19,6 +12,16 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"cloud.google.com/go/firestore"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/google/uuid"
+	"github.com/mholt/archiver"
+	"google.golang.org/api/iterator"
+
 	//"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	//"github.com/docker/docker/pkg/stdcopy"
@@ -257,7 +260,8 @@ func (c *FuzzitClient) CreateLocalJob(jobConfig Job, files []string) error {
 					"CORPUS_LINK=" + corpusLink,
 					"SEED_LINK=" + seedLink,
 					"ARGS=" + jobConfig.Args,
-					"LD_LIBRARY_PATH=/app"},
+					"LD_LIBRARY_PATH=/app",
+				},
 				jobConfig.EnvironmentVariables...),
 			Image:       "docker.io/fuzzitdev/fuzzit:stretch-llvm8",
 			Cmd:         []string{"/bin/sh", "/app/run.sh"},

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -17,9 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"log"
+
 	"github.com/fuzzitdev/fuzzit/client"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 // authCmd represents the auth command

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -16,8 +16,9 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // completionCmd represents the completion command

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -16,10 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"log"
+
 	"github.com/fuzzitdev/fuzzit/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"log"
 )
 
 // createCmd represents the create command

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -16,10 +16,11 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/fuzzitdev/fuzzit/client"
-	"github.com/spf13/cobra"
 	"log"
 	"strings"
+
+	"github.com/fuzzitdev/fuzzit/client"
+	"github.com/spf13/cobra"
 )
 
 // downloadCmd represents the download command
@@ -74,7 +75,6 @@ var downloadCmd = &cobra.Command{
 		} else {
 			log.Fatalf("resource should be either corpus or seed")
 		}
-
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -16,10 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"log"
+
 	"github.com/fuzzitdev/fuzzit/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"log"
 )
 
 // getCmd represents the get command

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -16,11 +16,12 @@ limitations under the License.
 package cmd
 
 import (
+	"log"
+	"strings"
+
 	"github.com/fuzzitdev/fuzzit/client"
 	"github.com/spf13/cobra"
 	"gopkg.in/src-d/go-git.v4"
-	"log"
-	"strings"
 )
 
 // jobCmd represents the job command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,12 +17,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/fuzzitdev/fuzzit/client"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/fuzzitdev/fuzzit/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var gFuzzitClient *client.FuzzitClient
@@ -46,7 +47,6 @@ func init() {
 	if err := viper.BindPFlag("api-key", rootCmd.PersistentFlags().Lookup("api-key")); err != nil {
 		log.Fatalln(err)
 	}
-
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/target.go
+++ b/cmd/target.go
@@ -16,8 +16,9 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"log"
+
+	"github.com/spf13/cobra"
 )
 
 // targetCmd represents the target command


### PR DESCRIPTION
This mainly keeps std imports tidy, and fixes a couple of newlines.