### PR TITLE
Install unzip to containers

### DIFF
--- a/docker/debian/buster/golang12-llvm9/Dockerfile
+++ b/docker/debian/buster/golang12-llvm9/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-buster
 
 LABEL maintainer="Fuzzit.dev, inc."
 
-RUN apt-get -qqy update && apt-get install -y wget gnupg2
+RUN apt-get -qqy update && apt-get install -y wget gnupg2 unzip
 
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster main" >> /etc/apt/sources.list
 RUN echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster main" >> /etc/apt/sources.list

--- a/docker/debian/stretch/golang12-llvm9/Dockerfile
+++ b/docker/debian/stretch/golang12-llvm9/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-stretch
 
 LABEL maintainer="Fuzzit.dev, inc."
 
-RUN apt-get -qqy update && apt-get install -y wget gnupg2
+RUN apt-get -qqy update && apt-get install -y wget gnupg2 unzip
 
 RUN echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" >> /etc/apt/sources.list
 RUN echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" >> /etc/apt/sources.list

--- a/docker/debian/stretch/llvm8/Dockerfile
+++ b/docker/debian/stretch/llvm8/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 LABEL maintainer="Fuzzit.dev, inc."
 
-RUN apt-get -qqy update && apt-get install -y wget gnupg2
+RUN apt-get -qqy update && apt-get install -y wget gnupg2 unzip
 
 RUN echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-8 main" >> /etc/apt/sources.list
 RUN echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch-8 main" >> /etc/apt/sources.list

--- a/docker/debian/stretch/llvm9/Dockerfile
+++ b/docker/debian/stretch/llvm9/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 LABEL maintainer="Fuzzit.dev, inc."
 
-RUN apt-get -qqy update && apt-get install -y wget gnupg2
+RUN apt-get -qqy update && apt-get install -y wget gnupg2 unzip
 
 RUN echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" >> /etc/apt/sources.list
 RUN echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" >> /etc/apt/sources.list


### PR DESCRIPTION
If corpus uploaded as zip file I get an error:

```
/app/run.sh: 25: /app/run.sh: unzip: not found
```

See https://github.com/fuzzitdev/fuzzit/blob/75c132b/client/utils.go#L91