### PR TITLE
Fix passing user defined args to libfuzzer job

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -180,14 +180,18 @@ func (c *FuzzitClient) uploadCrash(exitCode int) error {
 func (c *FuzzitClient) runLibFuzzerFuzzing() error {
 	ctx := context.Background()
 
-	args := []string{
-		"-print_final_stats=1",
-		"-exact_artifact_path=./artifact",
-		"-error_exitcode=76",
-		"-max_total_time=3600",
-		"corpus",
-		"seed",
-	}
+	args := append(
+		[]string{
+			"-print_final_stats=1",
+			"-exact_artifact_path=./artifact",
+			"-error_exitcode=76",
+			"-max_total_time=3600",
+		},
+		append(
+			strings.Split(c.currentJob.Args, " "),
+			"corpus", "seed",
+		)...,
+	)
 
 	var err error
 	err = nil
@@ -295,11 +299,18 @@ func (c *FuzzitClient) runLibFuzzerRegression() error {
 		return nil
 	}
 
-	args := append([]string{
-		"-print_final_stats=1",
-		"-exact_artifact_path=./artifact",
-		"-error_exitcode=76",
-	}, regressionFiles...)
+	args := append(
+		[]string{
+			"-print_final_stats=1",
+			"-exact_artifact_path=./artifact",
+			"-error_exitcode=76",
+		},
+		append(
+			strings.Split(c.currentJob.Args, " "),
+			regressionFiles...,
+		)...,
+	)
+
 	log.Println("Running regression...")
 	cmd := exec.Command("./fuzzer",
 		args...)

--- a/client/commands_test.go
+++ b/client/commands_test.go
@@ -45,7 +45,7 @@ func TestDownloadAndExtractCorpus(t *testing.T) {
 			err = tc.client.DownloadAndExtractCorpus(dir, tc.target)
 			if err != nil {
 				if err.Error() != tc.err {
-					t.Errorf("was expecting %s recieved %s", tc.err, err.Error())
+					t.Errorf("was expecting %s received %s", tc.err, err.Error())
 				}
 			} else {
 				if tc.err != "" {
@@ -95,7 +95,7 @@ func TestCreateLocalJob(t *testing.T) {
 			err := tc.client.CreateLocalJob(newJob, []string{"testdata/fuzzer.tar.gz"})
 			if err != nil {
 				if err.Error() != tc.err {
-					t.Errorf("was expecting %s recieved %s", tc.err, err.Error())
+					t.Errorf("was expecting %s received %s", tc.err, err.Error())
 				}
 			} else {
 				if tc.err != "" {

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -34,11 +34,11 @@ var jobCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if newJob.Type != "fuzzing" && newJob.Type != "regression" && newJob.Type != "local-regression" {
-			log.Fatalf("--type should be either fuzzing, regression or local-regression. Recieved: %s", newJob.Type)
+			log.Fatalf("--type should be either fuzzing, regression or local-regression. Received: %s", newJob.Type)
 		}
 
 		if newJob.Engine != "libfuzzer" && newJob.Engine != "jqf" {
-			log.Fatalf("--engine should be either libfuzzer or jqf. Recieved: %s", newJob.Type)
+			log.Fatalf("--engine should be either libfuzzer or jqf. Received: %s", newJob.Type)
 		}
 
 		image := client.HostToDocker[newJob.Host]


### PR DESCRIPTION
Currently command `./fuzzit create job --type fuzzing --args "-dict=fuzzing.dict -close_fd_mask=3" ...` ignores `--args`:

```
Running fuzzing with: ./fuzzer -print_final_stats=1 -exact_artifact_path=./artifact -error_exitcode=76 -max_total_time=3600 corpus seed
```