### PR TITLE
Add user args to libfuzzer corpus merging

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -118,6 +118,9 @@ func (c *FuzzitClient) runlibFuzzerMerge() error {
 		"merge",
 		"corpus",
 	}
+	if c.currentJob.Args != "" {
+		args = append(args, splitAndRemoveEmpty(c.currentJob.Args, " ")...)
+	}
 
 	log.Println("Running merge with: ./fuzzer " + strings.Join(args, " "))
 	cmd := exec.Command("./fuzzer",


### PR DESCRIPTION
For my case, when the binary is noisy, I'd like to pass `-close_fd_mask=3` to libfuzzer merging as well