### PR TITLE
Add jaeger to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ More information can be found in our [docs](https://docs.fuzzit.dev).
 - [lucas-clemente/quic-go](https://github.com/lucas-clemente/quic-go)
 - [gomarkdown/markdown](https://github.com/gomarkdown/markdown)
 - [pquerna/ffjson](https://github.com/pquerna/ffjson)
+- [jaegertracing/jaeger](https://github.com/jaegertracing/jaeger)
 
 * RUST
 - [CraneStation/cranelift](https://github.com/CraneStation/cranelift)


### PR DESCRIPTION
Adds the microservice monitoring system [jaeger](https://github.com/jaegertracing/jaeger) to the project list.

Closes #48.