### PR TITLE
Add pest to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ More information can be found in our [docs](https://docs.fuzzit.dev).
 * RUST
 - [CraneStation/cranelift](https://github.com/CraneStation/cranelift)
 - [image-rs/image-png](https://github.com/image-rs/image-png)
+- [pest-parser/pest](https://github.com/pest-parser/pest)
 
 * C/C++ 
 - [systemd/systemd](https://github.com/systemd/systemd)


### PR DESCRIPTION
Adds the [pest general-purpose parser](https://github.com/pest-parser/pest) to the project list.

Closes #52.