### PR TITLE
Add xlsx to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ More information can be found in our [docs](https://docs.fuzzit.dev).
 - [pquerna/ffjson](https://github.com/pquerna/ffjson)
 - [jaegertracing/jaeger](https://github.com/jaegertracing/jaeger)
 - [caddyserver/caddy](https://github.com/caddyserver/caddy/tree/v2)
+- [tealeg/xlsx](https://github.com/tealeg/xlsx)
 
 * RUST
 - [CraneStation/cranelift](https://github.com/CraneStation/cranelift)


### PR DESCRIPTION
Adds the [Excel library `xlsx`](https://github.com/tealeg/xlsx) to the project list.

Integrated in https://github.com/tealeg/xlsx/pull/473.